### PR TITLE
prepare.sh: check for wget before trying to run

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -24,6 +24,12 @@
 #
 ########################################################################
 
+# dependencies
+if [[ ! $(which "wget") ]]; then
+    echo -e >&2 "\n$(tput setaf 1)This script requires wget. Please install it first.$(tput sgr0)\n"
+    exit 1
+fi
+
 # variables
 VERSION="$1"
 DOMAIN="electron.atom.io"


### PR DESCRIPTION
`wget` doesn’t come preinstalled on OS X, so this warning is nice to have.
